### PR TITLE
Add timeout.patch: Increase epoll timeout to 100ms.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && git clone --single-branch --depth 1 https://github.com/TelegramMessenger/MTProxy.git /mtproxy/sources \
     && cd /mtproxy/sources \
     && patch -p0 -i /mtproxy/patches/randr_compat.patch \
+    && patch -p1 -i /mtproxy/patches/timeout.patch \
     && make -j$(getconf _NPROCESSORS_ONLN)
     # Let's skip all cleaning stuff for faster build
     # && cp /mtproxy/sources/objs/bin/mtproto-proxy /mtproxy/ \

--- a/patches/timeout.patch
+++ b/patches/timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/net/net-events.c b/net/net-events.c
+index 1a14377..3a051e2 100644
+--- a/net/net-events.c
++++ b/net/net-events.c
+@@ -411,7 +411,7 @@ int epoll_work (int timeout) {
+ 
+   double epoll_wait_start = get_utime_monotonic ();
+ 
+-  epoll_fetch_events (1);
++  epoll_fetch_events (100);
+ 
+   last_epoll_wait_at = get_utime_monotonic ();
+   double epoll_wait_time = last_epoll_wait_at - epoll_wait_start;


### PR DESCRIPTION
Current version of mtproxy consumes over 10% CPU time.
See https://github.com/TelegramMessenger/MTProxy/issues/100

Increasing timeout to 100ms doesn't break mtproxy for small and medium size
instances, but bring CPU consumption back to normal.

Signed-off-by: Alexander Gerasiov <gerasiov@yandex-team.ru>